### PR TITLE
Add test case when http appears in text

### DIFF
--- a/tests/htwgnlp/test_preprocessing.py
+++ b/tests/htwgnlp/test_preprocessing.py
@@ -39,6 +39,10 @@ processor = TweetProcessor()
             "URLs like this one: http://example.com and https://another.com",
             "URLs like this one:  and ",
         ),
+        (
+            "URLs with the http-protocol like this one: http://example.com and http://another.com",
+            "URLs with the http-protocol like this one:  and ",
+        ),
         ("https://example.com/with/path?query=1", ""),
     ],
 )


### PR DESCRIPTION
I added a test case that considers the case when `http` appears in the text and not in the URL.

Thanks for pointing this out @BenjaminBruenau 🚀 

closes #31 