### PR TITLE
Fix mathjax rendering

### DIFF
--- a/docs/javascripts/mathjax.js
+++ b/docs/javascripts/mathjax.js
@@ -1,0 +1,16 @@
+window.MathJax = {
+  tex: {
+    inlineMath: [["\\(", "\\)"]],
+    displayMath: [["\\[", "\\]"]],
+    processEscapes: true,
+    processEnvironments: true,
+  },
+  options: {
+    ignoreHtmlClass: ".*|",
+    processHtmlClass: "arithmatex",
+  },
+};
+
+document$.subscribe(() => {
+  MathJax.typesetPromise();
+});

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,7 @@ markdown_extensions:
       emoji_index: !!python/name:material.extensions.emoji.twemoji
       emoji_generator: !!python/name:material.extensions.emoji.to_svg
 extra_javascript:
+  - javascripts/mathjax.js
   - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 nav:


### PR DESCRIPTION
Seems like I forgot to add the necessary javascript.

References:

- https://github.com/squidfunk/mkdocs-material/issues/2530
- https://squidfunk.github.io/mkdocs-material/reference/math/?h=math+jax+typeset+promise#mathjax

closes #40
