### PR TITLE
Streamlined links in faq.md as per issue #144

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,9 +1,14 @@
+<!-- page links -->
+[course profile]: ./about/course_profile.md#assessment
+[Mural]: https://www.mural.co/
+[MkDocs]: https://www.mkdocs.org/
+
 # FAQ
 
 ## How is this course graded?
 
 The course is graded based on a written 90-minute exam at the end of the semester.
-For more details, see the [course profile](./about/course_profile.md#assessment).
+For more details, see the [course profile].
 
 ## When is an assignment considered completed?
 
@@ -11,13 +16,13 @@ An assignment is considered completed when all of its tests pass.
 
 ## How do I get access to the murals?
 
-The link to the murals will shared through the Moodle course or during the lecture.
+The link to the murals will be shared through the Moodle course or during the lecture.
 
-In order to access the murals, you will need to [create an account](https://www.mural.co/).
+In order to access the murals, you will need to [create an account][Mural].
 
 ## Is there a PDF version of the script?
 
-The content for this course was created using the [MkDocs](https://www.mkdocs.org/) framework.
+The content for this course was created using the [MkDocs] framework.
 As the course content is subject to continuous change, there is no PDF version of the script provided.
 But if you wish, you can convert any page to a PDF file by using the printing function of your browser.
 MkDocs will render a nice-looking PDF file without any menu or other web items.


### PR DESCRIPTION
Based on issue [#144](https://github.com/pkeilbach/htwg-practical-nlp/issues/144), I have updated the `faq.md` markdown file.

The following changes were made:
- All external links have been replaced with references at the start of the markdown file.
- Links are now in the correct format, improving the readability and maintainability of the markdown document.

These changes ensure a consistent link format in line with the project's requirements.