### PR TITLE
Check dependencies in Makefile (Issue 135)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,39 +17,44 @@ pip: venv
 venv:
 	python3 -m venv --upgrade-deps .venv
 
-# the following commands can only be used when `make` was executed successfully
-# TODO issue-135: print a hint on the console to execute `make`
-jupyter:
+# General check for any tool in .venv/bin, based on the target name
+check-%:
+	@if [ ! -f .venv/bin/$* ]; then \
+		echo "You need to execute 'make' first to install dependencies"; \
+		exit 1; \
+	fi
+
+jupyter: check-jupyter
 	.venv/bin/jupyter notebook --no-browser
 
-mkdocs:
+mkdocs: check-mkdocs
 	.venv/bin/mkdocs serve
 
-format:
+format: check-black
 	.venv/bin/black .
 
-type-check:
+type-check: check-mypy
 	.venv/bin/mypy src/
 
-lint:
+lint: check-ruff
 	.venv/bin/ruff check --fix
 	markdownlint --fix '**/*.md'
 
-pytest:
+pytest: check-pytest
 	.venv/bin/pytest
 
-assignment-0:
+assignment-0: check-pytest
 	.venv/bin/pytest tests/htwgnlp/test_python_basics.py
 
-assignment-1:
+assignment-1: check-pytest
 	.venv/bin/pytest tests/htwgnlp/test_preprocessing.py
 
-assignment-2:
+assignment-2: check-pytest
 	.venv/bin/pytest tests/htwgnlp/test_features.py
 	.venv/bin/pytest tests/htwgnlp/test_logistic_regression.py
 
-assignment-3:
+assignment-3: check-pytest
 	.venv/bin/pytest tests/htwgnlp/test_naive_bayes.py
 
-assignment-4:
+assignment-4: check-pytest
 	.venv/bin/pytest tests/htwgnlp/test_embeddings.py

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ venv:
 # General check for any tool in .venv/bin, based on the target name
 check-%:
 	@if [ ! -f .venv/bin/$* ]; then \
-		echo "You need to execute 'make' first to install dependencies"; \
+		echo "Tool '$*' not found in .venv/bin. Please run 'make' (or 'make install-dev') to install dependencies"; \
 		exit 1; \
 	fi
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -154,7 +154,7 @@ Jupyter is now accessible at <http://localhost:8888/>.
 If you want, you can bring up the lecture notes on your local machine.
 
 ```sh
-make docs
+make mkdocs
 ```
 
 The lecture notes are now accessible at <http://localhost:8000/>.


### PR DESCRIPTION
This pull request fixes Issue #135.

I wrote a tool check command in the Makefile, that checks if a tool is available in the venv directory. This check is done by name, e.g. 'check-jupyter' checks if the 'jupyter' tool is available in the venv dir, 'check-mkdocs' checks for 'mkdocs' in the venv dir, etc.. . This solution is a bit more elegant than the one proposed in the issue in my opinion.

Additionally i fixed a small mistake in the getting-started guide, since the make command is called "mkdocs" instead of just "docs". 