### PR TITLE
getting_started.md adjustments - adding upstream

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -171,7 +171,12 @@ git fetch upstream
 git checkout main
 git merge upstream/main
 
-# otherwise, you need to fetch from origin
+# make sure the correct upstream repository is set:
+git remote -v
+# if not, add the upstream:
+git remote add upstream https://github.com/pkeilbach/htwg-practical-nlp.git
+
+# otherwise (if you have cloned the repository), you need to fetch from origin
 git fetch origin
 git checkout main
 git merge origin/main


### PR DESCRIPTION
Adjustments in regard to the issue: Missing instructions for setting up upstream in getting_started.md [#181](https://github.com/pkeilbach/htwg-practical-nlp/issues/181)

The info, that the upstream might needs to be added to fetch updates are now included within the guide
