### PR TITLE
Add make command for pre-commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,3 +58,6 @@ assignment-3: check-pytest
 
 assignment-4: check-pytest
 	.venv/bin/pytest tests/htwgnlp/test_embeddings.py
+
+check-pre-commit:
+	.venv/bin/pre-commit run --all-files


### PR DESCRIPTION
This adds a make command to run the pre-commit hooks on all files locally. This potentially helps to prevent failed pipeline runs.